### PR TITLE
Adding OPCache as a PHP Extension

### DIFF
--- a/php/8.0-supervisor-debian/Dockerfile
+++ b/php/8.0-supervisor-debian/Dockerfile
@@ -11,7 +11,7 @@ RUN cp /usr/share/zoneinfo/$TZ /etc/localtime; \
     echo $TZ > /etc/timezone;
 
 # Install PHP extensions
-RUN docker-php-ext-install pdo_mysql pdo_sqlite mbstring exif pcntl bcmath gd curl zip intl
+RUN docker-php-ext-install pdo_mysql pdo_sqlite mbstring exif pcntl bcmath gd curl zip intl opcache
 
 RUN pecl install -o -f redis; \
     rm -rf /tmp/pear; \


### PR DESCRIPTION
Adding OPcache extension will allow us to enable OPCache module @ php.ini

What is OPCache?

OPcache is a caching engine built into PHP. When enabled, it dramatically increases the performance of websites that utilize PHP. 
It improves PHP performance by storing precompiled script bytecode in shared memory, thereby removing the need for PHP to load and parse scripts on each request.